### PR TITLE
Corrected spelling error

### DIFF
--- a/DeadReckoningLatency.md
+++ b/DeadReckoningLatency.md
@@ -99,7 +99,7 @@ Latency can also affect perceived cause-and-effect in simulations. Suppose we ha
 
 The artillery unit fires on the tank, and destroys it. The tank simulator changes its state to show itself as destroyed, and sends out a state update. From the perspective of the UAV the tank will be destroyed before the artillery fires. The artillery fires at t=0, and the tank simulator is informed at t=10. The tank in the simulator discovers it has been destroyed and sends out an update to its state. The new "destroyed" tank state arrives at the UAV at time t=30 (or 10 + 20). The artillery simulator's shot appears at the UAV simulator only at time t=100. The tanks explodes, and 70ms later we see the artillery that caused the explosion firing.
 
-This is sometimes called a causality violation. It may arise from other causes in addition to steady-state latency issues. Remember, UDP makes no guarantees about in-order packet delivery, or reliablity for that matter, so it's possible for UDP packets to arrive in a different order than which they were sent.
+This is sometimes called a causality violation. It may arise from other causes in addition to steady-state latency issues. Remember, UDP makes no guarantees about in-order packet delivery, or reliability for that matter, so it's possible for UDP packets to arrive in a different order than which they were sent.
 
 This can mitigated to an extent, certainly if the messages are being captured and replayed.  The <a href="PDUBundling.md">timestamp</a> field in the DIS PDU header can contain an absolute time hack, the time since the top of the hour.   If the simulation is so configured to use absolute time stamps this can be used to order the PDUs in rough absolute time order for replay and analysis.
 


### PR DESCRIPTION
Corrected a spelling error in the 'DeadReckoningLatency.md' file. The word 'reliablity' was incorrectly spelled in the 'Latency and Causation' section and has been corrected to 'reliability'.